### PR TITLE
Adds support for `AND`ed related resources in queries and triggers

### DIFF
--- a/src/prefect/events/schemas/automations.py
+++ b/src/prefect/events/schemas/automations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import textwrap
 from datetime import timedelta
@@ -103,7 +105,7 @@ class ResourceTrigger(Trigger, abc.ABC):
         default_factory=lambda: ResourceSpecification.model_validate({}),
         description="Labels for resources which this trigger will match.",
     )
-    match_related: ResourceSpecification = Field(
+    match_related: Union[ResourceSpecification, list[ResourceSpecification]] = Field(
         default_factory=lambda: ResourceSpecification.model_validate({}),
         description="Labels for related resources which this trigger will match.",
     )

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -6031,12 +6031,18 @@ export interface components {
             occurred?: components["schemas"]["EventOccurredFilter"];
             /** @description Filter criteria for the event name */
             event?: components["schemas"]["EventNameFilter"] | null;
-            /** @description Filter criteria for any resource involved in the event */
-            any_resource?: components["schemas"]["EventAnyResourceFilter"] | null;
             /** @description Filter criteria for the resource of the event */
             resource?: components["schemas"]["EventResourceFilter"] | null;
-            /** @description Filter criteria for the related resources of the event */
-            related?: components["schemas"]["EventRelatedFilter"] | null;
+            /**
+             * Related
+             * @description Filter criteria for the related resources of the event
+             */
+            related?: components["schemas"]["EventRelatedFilter"] | components["schemas"]["EventRelatedFilter"][] | null;
+            /**
+             * Any Resource
+             * @description Filter criteria for any resource involved in the event
+             */
+            any_resource?: components["schemas"]["EventAnyResourceFilter"] | components["schemas"]["EventAnyResourceFilter"][] | null;
             /** @description Filter criteria for the events' ID */
             id?: components["schemas"]["EventIDFilter"];
             /**
@@ -6182,8 +6188,11 @@ export interface components {
             id?: string;
             /** @description Labels for resources which this trigger will match. */
             match?: components["schemas"]["ResourceSpecification"];
-            /** @description Labels for related resources which this trigger will match. */
-            match_related?: components["schemas"]["ResourceSpecification"];
+            /**
+             * Match Related
+             * @description Labels for related resources which this trigger will match.
+             */
+            match_related?: components["schemas"]["ResourceSpecification"] | components["schemas"]["ResourceSpecification"][];
             /**
              * After
              * @description The event(s) which must first been seen to fire this trigger.  If empty, then fire this trigger immediately.  Events may include trailing wildcards, like `prefect.flow-run.*`

--- a/ui-v2/src/api/zod/events/events.ts
+++ b/ui-v2/src/api/zod/events/events.ts
@@ -117,31 +117,6 @@ export const readEventsEventsFilterPostBody = zod.object({
 				.or(zod.null())
 				.optional()
 				.describe("Filter criteria for the event name"),
-			any_resource: zod
-				.object({
-					id: zod
-						.array(zod.string())
-						.or(zod.null())
-						.optional()
-						.describe("Only include events for resources with these IDs"),
-					id_prefix: zod
-						.array(zod.string())
-						.or(zod.null())
-						.optional()
-						.describe(
-							"Only include events for resources with IDs starting with these prefixes",
-						),
-					labels: zod
-						.record(zod.string(), zod.string().or(zod.array(zod.string())))
-						.or(zod.null())
-						.optional()
-						.describe(
-							"Only include events for related resources with these labels",
-						),
-				})
-				.or(zod.null())
-				.optional()
-				.describe("Filter criteria for any resource involved in the event"),
 			resource: zod
 				.object({
 					id: zod
@@ -200,9 +175,93 @@ export const readEventsEventsFilterPostBody = zod.object({
 							"Only include events for related resources with these labels",
 						),
 				})
+				.or(
+					zod.array(
+						zod.object({
+							id: zod
+								.array(zod.string())
+								.or(zod.null())
+								.optional()
+								.describe(
+									"Only include events for related resources with these IDs",
+								),
+							role: zod
+								.array(zod.string())
+								.or(zod.null())
+								.optional()
+								.describe(
+									"Only include events for related resources in these roles",
+								),
+							resources_in_roles: zod
+								.array(zod.tuple([zod.string(), zod.string()]))
+								.or(zod.null())
+								.optional()
+								.describe(
+									"Only include events with specific related resources in specific roles",
+								),
+							labels: zod
+								.record(zod.string(), zod.string().or(zod.array(zod.string())))
+								.or(zod.null())
+								.optional()
+								.describe(
+									"Only include events for related resources with these labels",
+								),
+						}),
+					),
+				)
 				.or(zod.null())
 				.optional()
 				.describe("Filter criteria for the related resources of the event"),
+			any_resource: zod
+				.object({
+					id: zod
+						.array(zod.string())
+						.or(zod.null())
+						.optional()
+						.describe("Only include events for resources with these IDs"),
+					id_prefix: zod
+						.array(zod.string())
+						.or(zod.null())
+						.optional()
+						.describe(
+							"Only include events for resources with IDs starting with these prefixes",
+						),
+					labels: zod
+						.record(zod.string(), zod.string().or(zod.array(zod.string())))
+						.or(zod.null())
+						.optional()
+						.describe(
+							"Only include events for related resources with these labels",
+						),
+				})
+				.or(
+					zod.array(
+						zod.object({
+							id: zod
+								.array(zod.string())
+								.or(zod.null())
+								.optional()
+								.describe("Only include events for resources with these IDs"),
+							id_prefix: zod
+								.array(zod.string())
+								.or(zod.null())
+								.optional()
+								.describe(
+									"Only include events for resources with IDs starting with these prefixes",
+								),
+							labels: zod
+								.record(zod.string(), zod.string().or(zod.array(zod.string())))
+								.or(zod.null())
+								.optional()
+								.describe(
+									"Only include events for related resources with these labels",
+								),
+						}),
+					),
+				)
+				.or(zod.null())
+				.optional()
+				.describe("Filter criteria for any resource involved in the event"),
 			id: zod
 				.object({
 					id: zod
@@ -434,31 +493,6 @@ export const countAccountEventsEventsCountByCountablePostBody = zod.object({
 			.or(zod.null())
 			.optional()
 			.describe("Filter criteria for the event name"),
-		any_resource: zod
-			.object({
-				id: zod
-					.array(zod.string())
-					.or(zod.null())
-					.optional()
-					.describe("Only include events for resources with these IDs"),
-				id_prefix: zod
-					.array(zod.string())
-					.or(zod.null())
-					.optional()
-					.describe(
-						"Only include events for resources with IDs starting with these prefixes",
-					),
-				labels: zod
-					.record(zod.string(), zod.string().or(zod.array(zod.string())))
-					.or(zod.null())
-					.optional()
-					.describe(
-						"Only include events for related resources with these labels",
-					),
-			})
-			.or(zod.null())
-			.optional()
-			.describe("Filter criteria for any resource involved in the event"),
 		resource: zod
 			.object({
 				id: zod
@@ -513,9 +547,93 @@ export const countAccountEventsEventsCountByCountablePostBody = zod.object({
 						"Only include events for related resources with these labels",
 					),
 			})
+			.or(
+				zod.array(
+					zod.object({
+						id: zod
+							.array(zod.string())
+							.or(zod.null())
+							.optional()
+							.describe(
+								"Only include events for related resources with these IDs",
+							),
+						role: zod
+							.array(zod.string())
+							.or(zod.null())
+							.optional()
+							.describe(
+								"Only include events for related resources in these roles",
+							),
+						resources_in_roles: zod
+							.array(zod.tuple([zod.string(), zod.string()]))
+							.or(zod.null())
+							.optional()
+							.describe(
+								"Only include events with specific related resources in specific roles",
+							),
+						labels: zod
+							.record(zod.string(), zod.string().or(zod.array(zod.string())))
+							.or(zod.null())
+							.optional()
+							.describe(
+								"Only include events for related resources with these labels",
+							),
+					}),
+				),
+			)
 			.or(zod.null())
 			.optional()
 			.describe("Filter criteria for the related resources of the event"),
+		any_resource: zod
+			.object({
+				id: zod
+					.array(zod.string())
+					.or(zod.null())
+					.optional()
+					.describe("Only include events for resources with these IDs"),
+				id_prefix: zod
+					.array(zod.string())
+					.or(zod.null())
+					.optional()
+					.describe(
+						"Only include events for resources with IDs starting with these prefixes",
+					),
+				labels: zod
+					.record(zod.string(), zod.string().or(zod.array(zod.string())))
+					.or(zod.null())
+					.optional()
+					.describe(
+						"Only include events for related resources with these labels",
+					),
+			})
+			.or(
+				zod.array(
+					zod.object({
+						id: zod
+							.array(zod.string())
+							.or(zod.null())
+							.optional()
+							.describe("Only include events for resources with these IDs"),
+						id_prefix: zod
+							.array(zod.string())
+							.or(zod.null())
+							.optional()
+							.describe(
+								"Only include events for resources with IDs starting with these prefixes",
+							),
+						labels: zod
+							.record(zod.string(), zod.string().or(zod.array(zod.string())))
+							.or(zod.null())
+							.optional()
+							.describe(
+								"Only include events for related resources with these labels",
+							),
+					}),
+				),
+			)
+			.or(zod.null())
+			.optional()
+			.describe("Filter criteria for any resource involved in the event"),
 		id: zod
 			.object({
 				id: zod


### PR DESCRIPTION
Recreated from original PR: https://github.com/PrefectHQ/prefect/pull/18003

We've had some long-standing requests to add `AND`ing support to event
queries and triggering, to go along with the `OR`s supported in resource
label specification and the `AND`s between resource labels.  As a very
practical example, you can't currently target events that match a
certain work pool `AND` have a certain prefect tag.

This adds support for multiple related resources in all the places you
can request it:

* Event queries
* Triggering `match_related`

The general rule wil...